### PR TITLE
「相手のターンへ」アラートをクリック時に次のターンに遷移できるようにした

### DIFF
--- a/resources/views/game/board.blade.php
+++ b/resources/views/game/board.blade.php
@@ -72,7 +72,7 @@
             }
 
             Swal.fire(options).then(function () {
-                $('form').submit();
+                $('#board-form').submit();
             })
         })
     </script>


### PR DESCRIPTION
## チケット *
Ticket #61
* [ ] develop
* [x] fixed
* [ ] maintenance

## 変更のテーマ
* 
 
## やったこと *
> このプルリクでしたこと、使用した技術など

* jQueryのセレクタが存在しない要素を指していたため、適切なFormのidを指定した
  * アラートクリック時にPOSTリクエストが送信されるようになった
* スキップする場合の挙動も修正される

## やらないこと
> このプルリクではやらないこと

* 

## 動作確認 *
> 環境、確認内容

* ボット対戦モード、観戦モードで「相手のターンへ」を押した際に次のターンに遷移することを確認

## 影響範囲 *
* [x] なし
* [ ] あり

* 詳細 

## 課題
> 悩んでいること、とくにレビューしてほしいところ

* 

## 備考

* 


`*` : 入力推奨
